### PR TITLE
3: Unlock Jobs dependencies

### DIFF
--- a/src/ConsoleApp/Commands/RunJobsCommand.cs
+++ b/src/ConsoleApp/Commands/RunJobsCommand.cs
@@ -42,7 +42,7 @@ namespace ConsoleApp.Commands {
 
                     if (dependencies.Any()) {
                         dependencies.ForEach(x => addToTasks(x));
-                        tasks.Add(jobId, Task.WhenAll(dependencies.Select(x => tasks[x])).ContinueWith(x => jobs[jobId].Execute(debug), TaskContinuationOptions.OnlyOnRanToCompletion));
+                        tasks.Add(jobId, Task.WhenAll(dependencies.Select(x => tasks[x])).ContinueWith(x => jobs[jobId].Execute(debug), TaskContinuationOptions.None));
                     } else {
                         tasks.Add(jobId, Task.Run(() => jobs[jobId].Execute(debug)));
                     }

--- a/src/Test/AbstractJobTest.cs
+++ b/src/Test/AbstractJobTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -45,38 +46,9 @@ namespace Test {
             var expected = new[] {
                 TaskStatus.RanToCompletion,
                 TaskStatus.Faulted,
-                TaskStatus.Canceled,
                 TaskStatus.RanToCompletion,
-                TaskStatus.Canceled,
                 TaskStatus.RanToCompletion,
-            };
-
-            for (var i = 0; i < expected.Count(); i++) {
-                Assert.Equal(expected[i], tasks[jobList[i].Id()].Status);
-            }
-        }
-
-        [Fact]
-        public void FaultyRootJobExecution() {
-            var jobList = new AbstractJob[] {
-                new JobsHelper.JobA(true),
-                new JobsHelper.JobB(),
-                new JobsHelper.JobC(),
-                new JobsHelper.JobD(),
-                new JobsHelper.JobE(),
-                new JobsHelper.JobF(),
-            };
-
-            var jobs = RunJobsCommand.BuildJobsDict(jobList);
-            var tasks = RunJobsCommand.ScheduleJobs(jobs);
-            RunJobsCommand.WaitAll(tasks);
-
-            var expected = new[] {
-                TaskStatus.Faulted,
-                TaskStatus.Canceled,
-                TaskStatus.Canceled,
                 TaskStatus.RanToCompletion,
-                TaskStatus.Canceled,
                 TaskStatus.RanToCompletion,
             };
 


### PR DESCRIPTION
Addressed to #7

### Solution
To solve this issue we changed the dependencies policy from run a Job when the state of all previous States is `OnlyOnRanToCompletion`  to `None`.

This pull request includes:

- [x] Solve issue #7 
- [x] Update Test Unit