### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---.md
@@ -1,11 +1,15 @@
 ---
 name: "Bug report \U0001F41B"
 about: Create a report to help us improve
-title: ''
+title: update on issue check, changed to first line
 labels: ''
-assignees: ''
+assignees: lucaslovato
 
 ---
+
+<!-- Checked checkbox should look like this: [x] -->
+
+- [ ] I have searched the [issues](https://github.com/Marketing-Automation-Systems/jellyfish/issues/) of this repository and believe that this is not a duplicate.
 
 **Describe the bug 🐛**
 
@@ -15,10 +19,6 @@ assignees: ''
   Thank you very much for contributing to the Jellyfish team by creating an issue! ❤️
   To avoid duplicate issues we ask you to check off the following list.
 -->
-
-<!-- Checked checkbox should look like this: [x] -->
-
-- [ ] I have searched the [issues](https://github.com/Marketing-Automation-Systems/jellyfish/issues/) of this repository and believe that this is not a duplicate.
 
 **To Reproduce**
 Steps to reproduce the behavior 😯:


### PR DESCRIPTION
Change the issue check for the first line looks better than start a description without search for equal issues.