### PR TITLE
Fix discrepancy on Facebook data

### DIFF
--- a/src/ConsoleApp/schema/page_3.3.json
+++ b/src/ConsoleApp/schema/page_3.3.json
@@ -89,7 +89,7 @@
     }, {
         "name": "posts",
         "edges": [],
-        "required": ["object_id"],
+        "required": ["attachments"],
         "time": ["created_time", "updated_time"],
         "columns": [
             ["id", "text"],


### PR DESCRIPTION
 <!--
  Thank you very much for contributing to the Jellyfish team by creating a PR! ❤️
  To avoid duplicate PR we ask you to check off the following list.
-->

- [x] I have searched the [PR](https://github.com/Marketing-Automation-Systems/jellyfish/pulls/) of this repository and believe that this is not a duplicate.

<!-- Checked checkbox should look like this: [x] -->

**Describe the PR**

<!-- Provide a description of the changes proposed in the pull request -->
This PR closes #14 

In this PR, we are solving the bug related to Fetch Facebook Views. During the update from Graph API v3.1 to v3.3, we had to change some fields and these changes broke the Fetcher. To solve this problem we have to change the field **required** on the posts from `object_id` to `attachments` because object_i was deprecated on the API.

<!-- Short bullet list with the new changes proposed-->
**To Reproduce what was done**
Steps to reproduce the behavior:
1. Go to `src/ConsoleApp`
2. Run `dotnet run -- jobs -j Jobs.Fetcher.Facebook.page.posts`
3. See the changes on the table `facebook_v3_3.posts_insights_day`
4. Update the field **required** and run again
5. See the changes
<!-- Optional -->